### PR TITLE
PerfRepoMetric: get_name should return name instead of id

### DIFF
--- a/perfrepo/PerfRepoMetric.py
+++ b/perfrepo/PerfRepoMetric.py
@@ -45,7 +45,7 @@ class PerfRepoMetric(PerfRepoObject):
         return self._id
 
     def get_name(self):
-        return self._id
+        return self._name
 
     def get_description(self):
         return self._description


### PR DESCRIPTION
Signed-off-by: Jan Tluka <jtluka@redhat.com>