### PR TITLE
Fix PerfRepoReport permission code

### DIFF
--- a/perfrepo/PerfRepoReport.py
+++ b/perfrepo/PerfRepoReport.py
@@ -381,6 +381,12 @@ class PerfRepoReport(PerfRepoObject):
             self._set_element_atrib(value_elem, 'name', prop[0])
             self._set_element_atrib(value_elem, 'value', prop[1])
 
+        if len(self._permissions):
+            perms_elem = ElementTree.SubElement(root, 'permissions')
+            for perm in self._permissions:
+                perm_elem = perm.to_xml()
+                perms_elem.append(perm_elem)
+
         return root
 
     def __str__(self):

--- a/perfrepo/PerfRepoReport.py
+++ b/perfrepo/PerfRepoReport.py
@@ -428,8 +428,6 @@ class PerfRepoReportPermission(PerfRepoObject):
             if root.tag != "report-permission" and root.tag != "permission":
                 raise PerfRepoException("Invalid xml.")
 
-            self._id = root.find("id").text
-
             try:
                 self._report_id = root.find("report-id").text
             except:

--- a/perfrepo/PerfRepoReport.py
+++ b/perfrepo/PerfRepoReport.py
@@ -52,12 +52,14 @@ class PerfRepoReport(PerfRepoObject):
                 recursive_dict_update(self._properties, tmp_dict)
 
             self._permissions = []
-            for entry in root.find("permissions"):
-                if entry.tag != "permission":
-                    continue
-                self._permissions.append(PerfRepoReportPermission(entry))
-                self._permissions[-1].set_report_id(self._id)
-                self._permissions[-1].validate()
+            perms = root.find("permissions")
+            if perms is not None:
+                for entry in perms:
+                    if entry.tag != "permission":
+                        continue
+                    self._permissions.append(PerfRepoReportPermission(entry))
+                    self._permissions[-1].set_report_id(self._id)
+                    self._permissions[-1].validate()
         else:
             raise PerfRepoException("Parameter xml must be"\
                                     " a string, an Element or None")

--- a/perfrepo/PerfRepoReport.py
+++ b/perfrepo/PerfRepoReport.py
@@ -508,7 +508,7 @@ class PerfRepoReportPermission(PerfRepoObject):
     def to_xml(self):
         self.validate()
 
-        root = Element('report-permission')
+        root = Element('permission')
 
         id_elem = ElementTree.SubElement(root, 'report-id')
         id_elem.text = str(self._report_id)


### PR DESCRIPTION
All these issues found while doing:

```
report = perf_api.report_get_by_id(report)
old_xml = report.to_xml()
new_report = PerfRepoReport(old_xml)

```

The report must contain some permissions.